### PR TITLE
fix: use cookie store api only if available

### DIFF
--- a/app/(game)/(village-slug)/(preferences)/components/general-preferences.tsx
+++ b/app/(game)/(village-slug)/(preferences)/components/general-preferences.tsx
@@ -98,7 +98,6 @@ export const GeneralPreferences = () => {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="light">{t('Light')}</SelectItem>
-                <SelectItem value="dark">Dark</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/app/providers/cookie-provider.tsx
+++ b/app/providers/cookie-provider.tsx
@@ -11,7 +11,7 @@ import type {
 } from 'app/interfaces/models/game/preferences';
 import type { AvailableLocale } from 'app/interfaces/models/locale';
 import {
-  COOKIE_CUSTOM_EVENT,
+  COOKIE_UPDATE_EVENT_NAME,
   GRAPHICS_SKIN_VARIANT_COOKIE_NAME,
   GRAPHICS_TIME_OF_DAY_COOKIE_NAME,
   getCookie,
@@ -75,14 +75,14 @@ export const CookieProvider = ({ children }: PropsWithChildren) => {
     if (cookieStore) {
       cookieStore.addEventListener('change', updateCookies);
     } else {
-      document.addEventListener(COOKIE_CUSTOM_EVENT, updateCookies);
+      document.addEventListener(COOKIE_UPDATE_EVENT_NAME, updateCookies);
     }
 
     return () => {
       if (cookieStore) {
         cookieStore.removeEventListener('change', updateCookies);
       } else {
-        document.removeEventListener(COOKIE_CUSTOM_EVENT, updateCookies);
+        document.removeEventListener(COOKIE_UPDATE_EVENT_NAME, updateCookies);
       }
     };
   }, []);

--- a/app/utils/device.ts
+++ b/app/utils/device.ts
@@ -2,7 +2,8 @@ export const LOCALE_COOKIE_NAME = 'pillage-first-locale';
 export const UI_COLOR_SCHEME_COOKIE_NAME = 'pillage-first-ui-color-scheme';
 export const GRAPHICS_SKIN_VARIANT_COOKIE_NAME = 'pillage-first-skin-variant';
 export const GRAPHICS_TIME_OF_DAY_COOKIE_NAME = 'pillage-first-time-of-day';
-export const COOKIE_CUSTOM_EVENT = 'pillage-update-cookies';
+
+export const COOKIE_UPDATE_EVENT_NAME = 'pillage-first-cookies-update-event';
 
 export const isStandaloneDisplayMode = () => {
   return window.matchMedia('(display-mode: standalone)').matches;
@@ -28,11 +29,12 @@ export const setCookie = async <T extends string>(
       expires: expires.getTime(),
       path: '/',
     });
-  } else {
-    document.cookie = `${name}=${value}; expires=${expires.toUTCString()}`;
-    const event = new Event(COOKIE_CUSTOM_EVENT);
-    document.dispatchEvent(event);
+    return;
   }
+
+  document.cookie = `${name}=${value}; expires=${expires.toUTCString()}`;
+  const event = new Event(COOKIE_UPDATE_EVENT_NAME);
+  document.dispatchEvent(event);
 };
 
 export const getCookie = async (name: CookieName): Promise<string | null> => {
@@ -40,6 +42,7 @@ export const getCookie = async (name: CookieName): Promise<string | null> => {
     const cookie = await window.cookieStore.get(name);
     return cookie?.value || null;
   }
+
   const cookie = document.cookie
     .split('; ')
     .find((row) => row.startsWith(name));


### PR DESCRIPTION
As of right now, the `Cookie Store API` is the only implemented way of handling cookies.
Since the cookies are set in `entry.client.tsx`, the user can't play if the api is not available.