### PR TITLE
feat(wiki): add game world page

### DIFF
--- a/apps/web/app/(public)/(wiki)/(game-world)/mdx/content.mdx
+++ b/apps/web/app/(public)/(wiki)/(game-world)/mdx/content.mdx
@@ -1,0 +1,74 @@
+# Game world
+
+<section>
+  ## What is a game world?
+
+  A **game world** is a single, persistent map you play on. When you start a
+  new game, the world is generated procedurally from a seed: tiles, oases,
+  NPC players and their starting villages are all laid out at creation time
+  and remain stable for the entire lifetime of that world.
+
+  Everything in **Pillage First!** happens inside a game world. Your village,
+  your hero, your reports, your alliances and your enemies all live in the
+  same world and share the same map.
+</section>
+
+<section>
+  ## Where is the world stored?
+
+  Each game world lives **on your device**, as its own local save. There is
+  no central server keeping track of your progress, which is why you can
+  keep playing offline and why your save belongs to you.
+
+  This also means that:
+
+  * You can run **multiple worlds in parallel** without them interfering
+  with each other.
+  * You can **export a world** to a file and import it back later, or move
+  it to another device.
+  * Closing the tab or losing connection does not lose progress.
+</section>
+
+<section>
+  ## Time, speed and persistence
+
+  A world has its own clock. Buildings take time to construct, troops take
+  time to train, and movements take time to arrive. The pace at which all
+  of this happens is controlled by the world's **speed**, which you choose
+  when you create it.
+
+  A faster world compresses everything — construction, training, travel —
+  so you can experience more progression in less real-world time. A slower
+  world lets a single session feel more deliberate. Either way, the world
+  keeps simulating in the background, so you can step away and come back
+  later without feeling like you missed out.
+
+  Worlds are designed to be **long-form**. There is no hard time limit and
+  no forced reset; how long a world lasts is up to you.
+</section>
+
+<section>
+  ## NPC players
+
+  You are not alone in the world. At creation time, the world is populated
+  with **NPC players** spread across the map. They occupy villages, build
+  up over time, and are valid targets for raids, scouting and diplomacy
+  just like any human player would be.
+
+  This is what makes the single-player nature of the game still feel
+  competitive: there is always someone next door to interact with — peacefully
+  or otherwise.
+</section>
+
+<section>
+  ## Next up
+
+  Now that you know what the world is and how it's structured, the next
+  step is to look at **the players inside it** — starting with the
+  **Tribes**, which determine your starting buildings, units and economic
+  identity.
+
+  The **Tribes** page is coming soon. In the meantime, head back to the <a
+  className="text-blue-500 underline" href="/wiki">Wiki index</a> to see
+  the full list of topics.
+</section>

--- a/apps/web/app/(public)/(wiki)/(game-world)/page.tsx
+++ b/apps/web/app/(public)/(wiki)/(game-world)/page.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from 'app/components/ui/breadcrumb';
+import WikiGameWorldMdx from './mdx/content.mdx';
+
+const WikiGameWorldPage = () => {
+  const { t } = useTranslation('public');
+
+  const title = t('{{title}} | Pillage First!', {
+    title: 'Game world',
+  });
+
+  return (
+    <>
+      <title>{title}</title>
+      <div className="flex flex-col gap-4 max-w-3xl px-2 lg:px-0 mx-auto">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink to="/">{t('Home')}</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbLink to="/wiki">{t('Wiki')}</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>{t('Game world')}</BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <main className="flex flex-col gap-4">
+          <WikiGameWorldMdx />
+        </main>
+      </div>
+    </>
+  );
+};
+
+export default WikiGameWorldPage;

--- a/apps/web/app/(public)/(wiki)/(index)/mdx/content.mdx
+++ b/apps/web/app/(public)/(wiki)/(index)/mdx/content.mdx
@@ -9,8 +9,8 @@ below — each one builds on the previous.
 
   * <a className="text-blue-500 underline" href="/wiki/introduction">Introduction</a>
   — what the game is and what you're aiming for.
-  * **Game world** — how the persistent, offline-first world works.
-  *(coming soon)*
+  * <a className="text-blue-500 underline" href="/wiki/game-world">Game world</a>
+  — how the persistent, offline-first world works.
   * **Tribes** — the playable tribes and how they differ. *(coming soon)*
   * **Factions** — the NPC factions you'll interact with. *(coming soon)*
   * **Resources** — the four resources, production, storage and upkeep.

--- a/apps/web/app/(public)/(wiki)/(introduction)/mdx/content.mdx
+++ b/apps/web/app/(public)/(wiki)/(introduction)/mdx/content.mdx
@@ -37,7 +37,8 @@
   Once you're comfortable with the premise, the next thing to understand is
   **how the world itself works** — world size, speed, time and persistence.
 
-  The **Game world** page is coming soon. In the meantime, head back to the <a
-  className="text-blue-500 underline" href="/wiki">Wiki index</a> to see the
-  full list of topics.
+  Continue with the <a className="text-blue-500 underline" href="/wiki/game-world">Game world</a>
+  page, which walks you through world size, speed, time and persistence —
+  or head back to the <a className="text-blue-500 underline" href="/wiki">Wiki index</a>
+  to pick another topic.
 </section>

--- a/apps/web/app/(public)/(wiki)/components/wiki-main-navigation.tsx
+++ b/apps/web/app/(public)/(wiki)/components/wiki-main-navigation.tsx
@@ -144,6 +144,14 @@ export const WikiMainNavigation = ({
         to: '/wiki',
       },
       {
+        title: t('Introduction'),
+        to: '/wiki/introduction',
+      },
+      {
+        title: t('Game world'),
+        to: '/wiki/game-world',
+      },
+      {
         title: t('Units'),
         to: '/wiki/units',
         items: unitItems.sort((a, b) => a.title.localeCompare(b.title)),

--- a/apps/web/app/localization/locales/en-US/extracted/public.json
+++ b/apps/web/app/localization/locales/en-US/extracted/public.json
@@ -20,6 +20,7 @@
   "Fine-tune your experience with a variety of settings and options.": "Fine-tune your experience with a variety of settings and options.",
   "Frequently asked questions": "Frequently asked questions",
   "Game": "Game",
+  "Game world": "Game world",
   "Game worlds": "Game worlds",
   "Get involved": "Get involved",
   "Home": "Home",

--- a/apps/web/app/routes.ts
+++ b/apps/web/app/routes.ts
@@ -21,6 +21,7 @@ export default [
         layout('(public)/(wiki)/layout.tsx', [
           index('(public)/(wiki)/(index)/page.tsx'),
           route('introduction', '(public)/(wiki)/(introduction)/page.tsx'),
+          route('game-world', '(public)/(wiki)/(game-world)/page.tsx'),
           // ...prefix('units', [
           //   route(':unitId', '(public)/(wiki)/(units)/page.tsx'),
           // ]),

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -62,4 +62,11 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+
+  <url>
+    <loc>https://pillagefirst.com/wiki/game-world</loc>
+    <lastmod>2026-04-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/apps/web/react-router.config.ts
+++ b/apps/web/react-router.config.ts
@@ -16,6 +16,7 @@ const publicPagesToPrerender = [
   '/latest-updates',
   '/wiki',
   '/wiki/introduction',
+  '/wiki/game-world',
   '/404',
 ];
 


### PR DESCRIPTION
Hey! 👋

Second contribution following our chat on #186 — adds the **Game world** wiki page (`/wiki/game-world`) covering what a world is, where it's stored, time/speed/persistence, and NPC players.

Also slipped in two small touch-ups while I was there: the sidebar (`WikiMainNavigation`) now includes `Introduction` and `Game world` as direct entries, and the Introduction page's "Next up" section now links forward to the new page instead of saying *"coming soon"*.

Targeting `feat/wiki` as agreed. Happy to adjust anything 🙏